### PR TITLE
chore(envvar): remove APP_URL and rename WS_URL to public env

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -2,8 +2,7 @@ WATCHPACK_POLLING=true
 # Make sure to override these in deployment
 DATABASE_URL="postgresql://<username>:<password>@postgres:5432/clozet?schema=public&connect_timeout=30&pool_timeout=30&socket_timeout=30"
 
-APP_URL="localhost:3000"
-WS_URL="localhost:3001"
+NEXT_PUBLIC_WS_URL="localhost:3001"
 # Fallback port numbers for tRPC-related connections in ~/trpc/shared.ts
 PORT=""
 WS_PORT=""

--- a/app/.env.example
+++ b/app/.env.example
@@ -3,9 +3,6 @@ WATCHPACK_POLLING=true
 DATABASE_URL="postgresql://<username>:<password>@postgres:5432/clozet?schema=public&connect_timeout=30&pool_timeout=30&socket_timeout=30"
 
 NEXT_PUBLIC_WS_URL="localhost:3001"
-# Fallback port numbers for tRPC-related connections in ~/trpc/shared.ts
-PORT=""
-WS_PORT=""
 
 NEXTAUTH_URL="http://localhost:3000/api/auth"
 NEXTAUTH_SECRET="3000"

--- a/app/src/trpc/react.tsx
+++ b/app/src/trpc/react.tsx
@@ -16,7 +16,7 @@ import SuperJSON from 'superjson'
 
 import { type AppRouter } from '~/server/api/root'
 import { createQueryClient } from './query-client'
-import { getBaseUrl, getWsUrl } from './shared'
+import { getWsUrl } from './shared'
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined
 const getQueryClient = () => {
@@ -73,7 +73,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 function getEndingLink() {
   const batchLink = httpBatchLink({
     transformer: SuperJSON,
-    url: getBaseUrl() + '/api/trpc',
+    url: '/api/trpc',
     headers: () => {
       const headers = new Headers()
       headers.set('x-trpc-source', 'nextjs-react')

--- a/app/src/trpc/shared.ts
+++ b/app/src/trpc/shared.ts
@@ -1,10 +1,6 @@
-export function getBaseUrl() {
-  if (typeof window !== 'undefined') return window.location.origin
-  if (process.env.APP_URL) return `https://${process.env.APP_URL}`
-  return `http://localhost:${process.env.PORT ?? 3000}`
-}
-
 export function getWsUrl() {
-  if (process.env.WS_URL) return `ws://${process.env.WS_URL}`
-  return `ws://localhost:${process.env.WS_PORT ?? 3001}`
+  if (process.env.NEXT_PUBLIC_WS_URL)
+    return `wss://${process.env.NEXT_PUBLIC_WS_URL}`
+  // If on local development
+  return 'ws://localhost:3001'
 }


### PR DESCRIPTION
The current window location is the default for NextJS-tRPC links, and thus only the URL path needs to be specified

In addition, websocket envvar is converted to a public envvar as the function is executed on the client. Fallback would assume you're on local dev.

- Removed `APP_URL`, `PORT` and `WS_PORT` envvar
- Replaced `WS_URL` with `NEXT_PUBLIC_WS_URL`