### PR TITLE
feat(nginx): expose websocket on container and create volume for user configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Next.js Debug",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "cd app && npm run dev"
+    },
+  ]
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
     volumes:
       - nginx_secrets:/etc/letsencrypt
       - ./nginx/letsencrypt:/var/www/letsencrypt
+      - ./nginx/user_conf.d:/etc/nginx/conf.d
   prisma-studio:
     container_name: prisma-studio
     image: node:lts-alpine3.17

--- a/nginx/user_conf.d/server.example
+++ b/nginx/user_conf.d/server.example
@@ -21,4 +21,12 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
+
+    location /websocket {
+        proxy_pass http://nextjs-server:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_read_timeout 86400;
+    }
 }


### PR DESCRIPTION
also added a launch.json debug file for vscode debugging

## Problem
The current development environment creates a websocket server and exposes it via `localhost:3001`. However, we'd also need to ensure proper testing (i.e., using actual urls) in the future.


## Solution
- Expose the websocket server running on `localhost:3001` to `wss:<domain>/websocket` on the nginx container

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


**Breaking Changes**
- [x] No - this PR is backwards compatible  

**Notes (if your machine is used to both host and test the app)**
- If you don't set the envvar `NEXT_PUBLIC_WS_URL`, tRPC will redirect all subscription-based requests to `ws://localhost:3001` for local testing. If you want to use your own deployed domain to connect to the websocket server on your local machine, you'd need to edit `/etc/hosts` or your OS's equivalent to redirect traffic from `127.0.0.1` to whatever domain you have.
- If you configured everything correctly in the previous point, visiting your domain on your local machine shouldn't cause any issues
- A `Missing CSRF Token` error might occur if you don't configure it properly (i.e., you visit `localhost` but your Auth0 cookie is meant for your domain)
